### PR TITLE
add a fallback to go env GOPATH when GOPATH env is empty

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ run:
   # Default: true
   tests: true
 
-
   # Which dirs to skip: issues from them won't be reported.
   # Can use regexp here: `generated.*`, regexp is applied on full path.
   # Default value is empty list,
@@ -26,7 +25,6 @@ run:
   # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   # Default: true
   skip-dirs-use-default: true
-
 
   # If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit
@@ -80,7 +78,6 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - wsl
 
 linters-settings:
   dupl:
@@ -113,14 +110,13 @@ linters-settings:
     # Select the Go version to target.
     lang-version: "1.22.7"
 
-
   govet:
     # Report about shadowed variables
     check-shadowing: true
     enable-all: true
     disable:
       - fieldalignment
-    
+
   gosec:
     excludes:
       - G601
@@ -143,13 +139,13 @@ linters-settings:
 
   staticcheck:
     # https://staticcheck.io/docs/options#checks
-    checks: [ "all" ]
+    checks: ["all"]
     # Select the Go version to target.
     go: "1.22.7"
 
   whitespace:
-    multi-if: false  # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false  # Enforces newlines (or comments) after every multi-line function signature
+    multi-if: false # Enforces newlines (or comments) after every multi-line if statement
+    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
 
   wsl:
     # Controls if you may cuddle assignments and anything without needing an empty line between them.


### PR DESCRIPTION
### **User description**
## Summary
Improves `GOPATH()` function to be more robust by adding a fallback mechanism when the GOPATH environment variable is not set or empty.

## Changes
`utils/utils.go`
  - Enhanced GOPATH detection (`utils/utils.go:47-69`): Modified the GOPATH() function to try multiple sources:
    1. First checks the GOPATH environment variable
    2. Falls back to executing go env GOPATH command if env var is unset or empty
    3. Returns empty slice as last resort with an appropriate error message
  - Updated function documentation to reflect the new fallback behavior
  - Import organization: Added `os/exec` and reorganized imports (moved strings to standard library section)
`utils/utils_test.go`
  - Comprehensive test coverage (`utils/utils_test.go:169-232`): Added `TestGOPATH()` with multiple test cases:
    - WithEnvironmentVariable: Verifies behavior when GOPATH env var is set
    - WithMultiplePathsInEnvironment: Tests handling of multiple paths separated by OS-specific path separator
    - FallbackToGoEnvCommand: Confirms fallback mechanism works when env var is unset
    - WithEmptyEnvironmentVariable: Validates fallback when env var is empty string
  - Tests properly clean up environment changes using `t.Cleanup()`

## Motivation
The original implementation relied solely on the GOPATH environment variable, which may not always be set in modern Go development environments (Go 1.11+ with modules). This change ensures the code can still determine the GOPATH by falling back to the `go env GOPATH` command, which is the recommended approach.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Improves `GOPATH()` function robustness by adding fallback to `go env GOPATH` command when `GOPATH` env var is unset or empty

- Adds comprehensive test coverage for `GOPATH()` in `utils/utils_test.go`:
  - Verifies behavior with `GOPATH` env var set, unset, and empty
  - Tests handling of multiple paths in `GOPATH`
  - Confirms proper fallback to `go env GOPATH`

- Updates `GOPATH()` function documentation to reflect new fallback behavior

- Reorganizes imports in `utils/utils.go`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check GOPATH<br>env var"] --> B{"GOPATH<br>set and<br>non-empty?"}
  B -->|Yes| C(("Return GOPATH<br>paths"))
  B -->|No| D["Run 'go env GOPATH'<br>command"]
  D --> E{"Command<br>output<br>non-empty?"}
  E -->|Yes| F(("Return command<br>output paths"))
  E -->|No| G(("Return empty slice"))
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Improve GOPATH() robustness and update docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/utils.go

<ul><li>Enhances <code>GOPATH()</code> function with fallback to <code>go env GOPATH</code> command<br> <li> Updates <code>GOPATH()</code> function documentation <br> <li> Reorganizes imports</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/qor/pull/5/files#diff-0df82f8689d3e8d881be0653ab4e9f8221c5835ec95a14930d11669e9c7f07ef">+23/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_test.go</strong><dd><code>Add thorough tests for GOPATH() function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/utils_test.go

<ul><li>Adds comprehensive test coverage for <code>GOPATH()</code> function<br> <li> Tests various scenarios: env var set, unset, empty, multiple paths<br> <li> Verifies proper fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/qor/pull/5/files#diff-42d685424866f20e83de4d713cb6a4cefebdc92f8cf168e25a09915f0100fd39">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

